### PR TITLE
Compliant Solution R07_ERR50_J.java

### DIFF
--- a/R07_ERR50_J.java
+++ b/R07_ERR50_J.java
@@ -2,20 +2,10 @@
  *Rule 07: Exceptional Behavior (ERR)
  *ERR50-J. Use exceptions only for exceptional conditions
  ******************************************************************************/
-public String processSingleString(String string){
-    // . . .
-    return string;
-  }
-public String processStrings(String[] strings){
-  String result = "";
-  int i = 0;
-  try{
-    while(true){
-      result = result.concat(processSingleString(string[i]));
-      i++;
+public String processSingleString(String[] string){
+    String result = "";
+    for(int i=0; i<strings.length; i++){
+        result = result.concat(processSingleString(strings[i]));
     }
-  }catch(ArrayIndexOutOfBoundsException e){
-    //ignore, we're done
-  }
-  return result;
+    return result;
 }


### PR DESCRIPTION
uses a for loop to concatenate the strings.
This code does not need ArraryIndexOutOfBoundsException because it is a runtime exception, and such exceptions indicate programmer errors, which are best resolved by fixing the defect.